### PR TITLE
Avoid potential double driver registration

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -161,5 +161,10 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 func init() {
+	for _, driver := range sql.Drivers() {
+		if driver == "mysql" {
+			return
+		}
+	}
 	sql.Register("mysql", &MySQLDriver{})
 }


### PR DESCRIPTION
This helps to resolve an issue with double database driver registration when dependencies import the package twice independently.
Originally happened to me when using go migration script via goose migration tool.